### PR TITLE
Require component -dev packages use same version

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -55,11 +55,11 @@ Description: Ignition Common classes and functions (core) - Development files
 Package: libignition-common5-dev
 Architecture: any
 Section: libdevel
-Depends: libignition-common5-core-dev,
-         libignition-common5-av-dev,
-	 libignition-common5-events-dev,
-	 libignition-common5-graphics-dev,
-	 libignition-common5-profiler-dev,
+Depends: libignition-common5-core-dev (= ${binary:Version}),
+         libignition-common5-av-dev (= ${binary:Version}),
+         libignition-common5-events-dev (= ${binary:Version}),
+         libignition-common5-graphics-dev (= ${binary:Version}),
+         libignition-common5-profiler-dev (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
 Description: Ignition Common classes and functions for robot apps - Metapackage
@@ -86,7 +86,7 @@ Package: libignition-common5-av-dev
 Architecture: any
 Section: libdevel
 Depends: libignition-cmake2-dev,
-         libignition-common5-core-dev,
+         libignition-common5-core-dev (= ${binary:Version}),
          libignition-utils1-dev,
          libavdevice-dev,
          libavformat-dev,
@@ -122,7 +122,7 @@ Package: libignition-common5-events-dev
 Architecture: any
 Section: libdevel
 Depends: libignition-cmake2-dev,
-         libignition-common5-core-dev,
+         libignition-common5-core-dev (= ${binary:Version}),
          libignition-utils1-dev,
          libignition-math6-dev,
          libignition-common5-events (= ${binary:Version}),
@@ -154,7 +154,7 @@ Package: libignition-common5-graphics-dev
 Architecture: any
 Section: libdevel
 Depends: libignition-cmake2-dev,
-         libignition-common5-core-dev,
+         libignition-common5-core-dev (= ${binary:Version}),
          libignition-math6-dev,
          libignition-utils1-dev,
          libtinyxml2-dev,
@@ -188,7 +188,7 @@ Package: libignition-common5-profiler-dev
 Architecture: any
 Section: libdevel
 Depends: libignition-cmake2-dev,
-         libignition-common5-core-dev,
+         libignition-common5-core-dev (= ${binary:Version}),
          libignition-common5-profiler (= ${binary:Version}),
          ${misc:Depends}
 Breaks: libignition-common5-dev (<< 3.0.0~pre5+hg20190228r1b2df90990)


### PR DESCRIPTION
This is the same changes as ignition-release/ign-common3-release#1 as part of ignition-tooling/release-tools#469