### PR TITLE
Add gz Rules

### DIFF
--- a/ubuntu/debian/libignition-common-av-dev.install
+++ b/ubuntu/debian/libignition-common-av-dev.install
@@ -1,5 +1,7 @@
 usr/include/ignition/common*/ignition/common/av.hh
 usr/include/ignition/common*/ignition/common/av/*
+usr/include/ignition/common*/gz/common/av.hh
+usr/include/ignition/common*/gz/common/av/*
 usr/lib/*/cmake/ignition-common[0-99]-av/*
 usr/lib/*/libignition-common[0-99]-av.so
 usr/lib/*/pkgconfig/ignition-common[0-99]-av.pc

--- a/ubuntu/debian/libignition-common-core-dev.install
+++ b/ubuntu/debian/libignition-common-core-dev.install
@@ -1,6 +1,9 @@
 usr/include/ignition/common[0-99]/ignition/common.hh
 usr/include/ignition/common[0-99]/ignition/common/*.hh
 usr/include/ignition/common[0-99]/ignition/common/detail/*.hh
+usr/include/ignition/common[0-99]/gz/common.hh
+usr/include/ignition/common[0-99]/gz/common/*.hh
+usr/include/ignition/common[0-99]/gz/common/detail/*.hh
 usr/lib/*/libignition-common[0-99].so
 usr/lib/*/pkgconfig/ignition-common[0-99].pc
 usr/lib/*/cmake/ignition-common[0-99]/ignition-common*

--- a/ubuntu/debian/libignition-common-events-dev.install
+++ b/ubuntu/debian/libignition-common-events-dev.install
@@ -1,5 +1,7 @@
 usr/include/ignition/common*/ignition/common/events.hh
 usr/include/ignition/common*/ignition/common/events/*
+usr/include/ignition/common*/gz/common/events.hh
+usr/include/ignition/common*/gz/common/events/*
 usr/lib/*/cmake/ignition-common[0-99]-events/*
 usr/lib/*/libignition-common[0-99]-events.so
 usr/lib/*/pkgconfig/ignition-common[0-99]-events.pc

--- a/ubuntu/debian/libignition-common-geospatial-dev.install
+++ b/ubuntu/debian/libignition-common-geospatial-dev.install
@@ -1,5 +1,7 @@
 usr/include/ignition/common*/ignition/common/geospatial.hh
 usr/include/ignition/common*/ignition/common/geospatial/*
+usr/include/ignition/common*/gz/common/geospatial.hh
+usr/include/ignition/common*/gz/common/geospatial/*
 usr/lib/*/cmake/ignition-common[0-99]-geospatial/*
 usr/lib/*/libignition-common[0-99]-geospatial.so
 usr/lib/*/pkgconfig/ignition-common[0-99]-geospatial.pc

--- a/ubuntu/debian/libignition-common-graphics-dev.install
+++ b/ubuntu/debian/libignition-common-graphics-dev.install
@@ -1,5 +1,7 @@
 usr/include/ignition/common*/ignition/common/graphics.hh
 usr/include/ignition/common*/ignition/common/graphics/*
+usr/include/ignition/common*/gz/common/graphics.hh
+usr/include/ignition/common*/gz/common/graphics/*
 usr/lib/*/cmake/ignition-common[0-99]-graphics/*
 usr/lib/*/libignition-common[0-99]-graphics.so
 usr/lib/*/pkgconfig/ignition-common[0-99]-graphics.pc

--- a/ubuntu/debian/libignition-common-profiler-dev.install
+++ b/ubuntu/debian/libignition-common-profiler-dev.install
@@ -1,4 +1,5 @@
 usr/include/ignition/common*/ignition/common/profiler/*
+usr/include/ignition/common*/gz/common/profiler/*
 usr/lib/*/cmake/ignition-common[0-99]-profiler/*
 usr/lib/*/libignition-common[0-99]-profiler.so
 usr/lib/*/pkgconfig/ignition-common[0-99]-profiler.pc

--- a/ubuntu/debian/libignition-common-testing-dev.install
+++ b/ubuntu/debian/libignition-common-testing-dev.install
@@ -1,5 +1,7 @@
 usr/include/ignition/common*/ignition/common/testing.hh
+usr/include/ignition/common*/gz/common/testing.hh
 usr/include/ignition/common*/ignition/common/testing/*
+usr/include/ignition/common*/gz/common/testing/*
 usr/lib/*/cmake/ignition-common[0-99]-testing/*
 usr/lib/*/libignition-common[0-99]-testing.so
 usr/lib/*/pkgconfig/ignition-common[0-99]-testing.pc

--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -15,6 +15,11 @@ override_dh_install:
 	$(RM) debian/libignition-common5-core-dev/usr/include/ignition/common*/ignition/common/geospatial.hh
 	$(RM) debian/libignition-common5-core-dev/usr/include/ignition/common*/ignition/common/graphics.hh
 	$(RM) debian/libignition-common5-core-dev/usr/include/ignition/common*/ignition/common/testing.hh
+	$(RM) debian/libignition-common5-core-dev/usr/include/ignition/common*/gz/common/av.hh
+	$(RM) debian/libignition-common5-core-dev/usr/include/ignition/common*/gz/common/events.hh
+	$(RM) debian/libignition-common5-core-dev/usr/include/ignition/common*/gz/common/geospatial.hh
+	$(RM) debian/libignition-common5-core-dev/usr/include/ignition/common*/gz/common/graphics.hh
+	$(RM) debian/libignition-common5-core-dev/usr/include/ignition/common*/gz/common/testing.hh
 	dh_missing --list-missing
 
 # test cannot run in parallel


### PR DESCRIPTION
Without these rules, the gz headers won't install properly, and debbuilds fail.

See: https://github.com/ignition-tooling/release-tools/issues/711