### PR TITLE
Suppress pragma warning in generated test

### DIFF
--- a/ubuntu/debian/tests/build
+++ b/ubuntu/debian/tests/build
@@ -11,6 +11,8 @@ trap "rm -rf $WORKDIR" 0 INT QUIT ABRT PIPE TERM
 cd $WORKDIR
 cat <<EOF > igntest.c
 
+#define SUPPRESS_IGNITION_HEADER_DEPRECATION
+
 #include <iostream>
 #include <ignition/common/Base64.hh>
 
@@ -22,6 +24,9 @@ int main(int argc, char **argv)
 
     return 0;
 }
+
+#undef SUPPRESS_IGNITION_HEADER_DEPRECATION
+
 EOF
 
 g++ -o igntest igntest.c `pkg-config --cflags --libs ignition-common5`


### PR DESCRIPTION
The changes added in https://github.com/gazebosim/gz-common/pull/356 cause pragma warnings to be emitted whenever an `ignition` header is included. But it also implements logic to suppress them if they're expected.

We need to suppress it here.


[![Build Status](https://build.osrfoundation.org/view/ign-garden/job/ign-common5-debbuilder/439/badge/icon)](https://build.osrfoundation.org/view/ign-garden/job/ign-common5-debbuilder/439/)