### PR TITLE
Add direct dependency on libfreeimage-dev for graphics component

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -216,6 +216,7 @@ Package: libgz-common5-graphics-dev
 Architecture: any
 Section: libdevel
 Depends: libassimp-dev,
+         libfreeimage-dev,
          libgts-dev,
          libgz-cmake3-dev,
          libgz-common5-core-dev (= ${binary:Version}),


### PR DESCRIPTION
I was testing out our new setup-gazebo action and wanted to use it to build our API docs and noticed that installing `gz-harmonic` with `--no-install-recommends` ends up not installing Freeimage. The `gz-common5-graphics` component is installed, but since Freeimage is missing, downstream builds that depend on gz-common5-graphics fail.

https://github.com/azeey/docs/actions/runs/9687624624/job/26732590512

cc @mjcarroll 